### PR TITLE
Clean up controller client to use monotonic time and warn caller about incorrect usage of zmq client.

### DIFF
--- a/python/mujincontrollerclient/__init__.py
+++ b/python/mujincontrollerclient/__init__.py
@@ -1,5 +1,13 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2014-2015 MUJIN Inc.
+# Copyright (C) 2014-2018 MUJIN Inc.
+
+# use GetMonotonicTime if possible
+try:
+    from mujincommon import GetMonotonicTime
+except ImportError:
+    import time
+    def GetMonotonicTime():
+        return time.time()
 
 try:
     import mujincommon.i18n
@@ -13,26 +21,6 @@ except ImportError:
 _ = ugettext
 
 import json
-
-from logging import addLevelName, NOTSET, getLoggerClass
-
-VERBOSE = 5
-
-class MujinLogger(getLoggerClass()):
-    def __init__(self, name, level=NOTSET):
-        super(MujinLogger, self).__init__(name, level)
-
-        addLevelName(VERBOSE, "VERBOSE")
-    
-    def verbose(self, msg, *args, **kwargs):
-        if self.isEnabledFor(VERBOSE):
-            self._log(VERBOSE, msg, args, **kwargs)
-
-#     def __eq__(self, r):
-#         return self.msg == r.msg
-#     
-#     def __ne__(self, r):
-#         return self.msg != r.msg
 
 class ClientExceptionBase(Exception):
     """client base exception
@@ -141,14 +129,3 @@ class BinPickingError(ClientExceptionBase):
 class HandEyeCalibrationError(ClientExceptionBase):
     def __unicode__(self):
         return _('Hand-eye Calibration Client Error:\n%s')%self.msg
-
-from traceback import format_exc
-
-
-def GetExceptionStack():
-    """returns the unicode of format_exc
-    """
-    s = format_exc()
-    if isinstance(s, unicode):
-        return s
-    return unicode(s, 'utf-8')

--- a/python/mujincontrollerclient/controllerclientraw.py
+++ b/python/mujincontrollerclient/controllerclientraw.py
@@ -24,7 +24,7 @@ try:
 except ImportError:
     import json
 
-from . import ControllerClientError
+from . import GetMonotonicTime, TimeoutError
 from . import APIServerError, AuthenticationError, GetAPIServerErrorFromWeb
 from . import ugettext as _
 
@@ -267,11 +267,11 @@ class ControllerWebClient(object):
         jobpk = response['jobpk']
         # query the task results
         status_text_prev = None
-        starttime = time.time()
+        starttime = GetMonotonicTime()
         try:
             while self._isok:
                 try:
-                    if timeout is not None and time.time() - starttime > timeout:
+                    if timeout is not None and GetMonotonicTime() - starttime > timeout:
                         raise TimeoutError('failed to get result in time, quitting')
                     try:
                         status, response = self.APICall('GET', u'job/%s' % jobpk, timeout=5)
@@ -337,11 +337,11 @@ class ControllerWebClient(object):
         jobpk = response['jobpk']
         # query the task results
         status_text_prev = None
-        starttime = time.time()
+        starttime = GetMonotonicTime()
         try:
             while self._isok:
                 try:
-                    if timeout is not None and time.time() - starttime > timeout:
+                    if timeout is not None and GetMonotonicTime() - starttime > timeout:
                         raise TimeoutError('failed to get result in time, quitting')
                     try:
                         status, response = self.APICall('GET', u'job/%s' % jobpk, timeout=5)

--- a/python/mujincontrollerclient/zmqclient.py
+++ b/python/mujincontrollerclient/zmqclient.py
@@ -4,19 +4,12 @@
 import zmq
 import threading
 
-from . import TimeoutError
+from . import TimeoutError, GetMonotonicTime
 
 # logging
 import logging
 log = logging.getLogger(__name__)
 
-# use GetMonotonicTime if possible
-try:
-    from mujincommon import GetMonotonicTime
-except ImportError:
-    import time
-    def GetMonotonicTime():
-        return time.time()
 
 class ZmqSocketPool(object):
 
@@ -292,7 +285,9 @@ class ZmqClient(object):
         oldcallerthread = self._callerthread
         self._callerthread = callerthread
         if oldcallerthread is not None:
-            assert oldcallerthread == callerthread, 'zmqclient used from multiple threads: previously = %s, now = %s' % (oldcallerthread, callerthread)
+            # assert oldcallerthread == callerthread, 'zmqclient used from multiple threads: previously = %s, now = %s' % (oldcallerthread, callerthread)
+            if oldcallerthread != callerthread:
+                log.error('zmqclient used from multiple threads, this is a bug in the caller: previously = %s, now = %s' % (oldcallerthread, callerthread))
 
     def _AcquireSocket(self, timeout=None):
         # if we were holding on to a socket before, release it before acquiring one


### PR DESCRIPTION
This change will:

1. use monotonic time to do timeout when possible
2. warn developer who uses the zmq client from multiple threads
3. remove some dead code