### PR TITLE
Add max_retries to deal with timed out keep-alive connections.

### DIFF
--- a/python/mujincontrollerclient/controllerclientraw.py
+++ b/python/mujincontrollerclient/controllerclientraw.py
@@ -14,6 +14,7 @@
 import os
 import requests
 import requests.auth
+import requests.adapters
 
 from . import json
 from . import GetAPIServerErrorFromWeb
@@ -38,13 +39,22 @@ class ControllerWebClient(object):
         self._headers = {}
         self._isok = True
 
+        # create session
+        self._session = requests.Session()
+
+        # use basic auth
+        self._session.auth = requests.auth.HTTPBasicAuth(self._username, self._password)
+
+        # set csrftoken
         # any string can be the csrftoken
         self._headers['X-CSRFToken'] = 'csrftoken'
-
-        self._session = requests.Session()
-        self._session.auth = requests.auth.HTTPBasicAuth(self._username, self._password)
         self._session.cookies.set('csrftoken', self._headers['X-CSRFToken'], path='/')
 
+        # add retry to deal with closed keep alive connections
+        self._session.mount('https://', requests.adapters.HTTPAdapter(max_retries=3))
+        self._session.mount('http://', requests.adapters.HTTPAdapter(max_retries=3))
+
+        # set locale headers
         self.SetLocale(locale)
 
     def __del__(self):
@@ -75,12 +85,6 @@ class ControllerWebClient(object):
         headers = dict(headers or {})
         headers.update(self._headers)
 
-        # for GET and HEAD requests, have a retry logic in case keep alive connection is being closed by server
-        if method in ('GET', 'HEAD'):
-            try:
-                return self._session.request(method=method, url=url, timeout=timeout, headers=headers, **kwargs)
-            except requests.ConnectionError as e:
-                log.warn('caught connection error, maybe server is racing to close keep alive connection, try again: %s', e)
         return self._session.request(method=method, url=url, timeout=timeout, headers=headers, **kwargs)
 
     # python port of the javascript API Call function


### PR DESCRIPTION
Fixes errors like:

```
2019-01-29 16:50:50,829 keepalive [ERROR] [keepalive.py:21 _RunThread] test failed: ('Connection aborted.', BadStatusLine("''",))
Traceback (most recent call last):
  File "/private/keepalive.py", line 18, in _RunThread
    client._webclient.Request('PUT', '/u/', timeout=60)  # use a POST request so we won't retry automatically
  File "/opt/lib/python2.7/site-packages/mujincontrollerclient/controllerclientraw.py", line 86, in Request
    return self._session.request(method=method, url=url, timeout=timeout, headers=headers, **kwargs)
  File "/opt/lib/python2.7/site-packages/requests/sessions.py", line 464, in request
    resp = self.send(prep, **send_kwargs)
  File "/opt/lib/python2.7/site-packages/requests/sessions.py", line 576, in send
    r = adapter.send(request, **kwargs)
  File "/opt/lib/python2.7/site-packages/requests/adapters.py", line 415, in send
    raise ConnectionError(err, request=request)
ConnectionError: ('Connection aborted.', BadStatusLine("''",))
ConnectionError(ProtocolError('Connection aborted.', BadStatusLine("''",)),)
```

See https://git.mujin.co.jp/snippets/127 for reproduction.