### PR TITLE
Add UserInterrupt to zmqclient, prevent returning None.

### DIFF
--- a/python/mujincontrollerclient/__init__.py
+++ b/python/mujincontrollerclient/__init__.py
@@ -125,3 +125,6 @@ class ControllerClientError(ClientExceptionBase):
 
 class URIError(ClientExceptionBase):
     pass
+
+class UserInterrupt(ClientExceptionBase):
+    pass

--- a/python/mujincontrollerclient/zmqclient.py
+++ b/python/mujincontrollerclient/zmqclient.py
@@ -4,7 +4,7 @@
 import threading
 
 from . import zmq
-from . import TimeoutError, GetMonotonicTime
+from . import TimeoutError, UserInterrupt, GetMonotonicTime
 
 import logging
 log = logging.getLogger(__name__)
@@ -94,7 +94,7 @@ class ZmqSocketPool(object):
 
     def _OpenSocket(self):
         if not self._isok:
-            return None
+            raise UserInterrupt(u'Interrupted while opening new socket, ZMQ socket pool is stopping')
 
         socket = self._ctx.socket(zmq.REQ)
         socket.connect(self._url)
@@ -201,8 +201,7 @@ class ZmqSocketPool(object):
             # otherwise, wait by a small blocking poll
             self._Poll(timeout=50)
 
-        # TODO: raise UserInterrupt
-        return None
+        raise UserInterrupt(u'Interrupted while acquiring socket, ZMQ socket pool is stopping')
 
     def ReleaseSocket(self, socket, reuse=True):
         """release a socket after use, if caller did not call recv, the pool will take care of that
@@ -334,9 +333,8 @@ class ZmqClient(object):
         self._AcquireSocket(timeout=timeout, checkpreempt=checkpreempt)
 
         # we may be exiting, the pool refused to give us a socket
-        if not self._isok or self._socket is None:
-            # TODO: raise UserInterrupt
-            return None
+        if not self._isok:
+            raise UserInterrupt(u'Interrupted after acquiring socket, ZMQ client is stopping')
 
         releasesocket = True
         try:
@@ -381,8 +379,7 @@ class ZmqClient(object):
             if releasesocket:
                 self._ReleaseSocket()
 
-        # TODO: raise UserInterrupt
-        return None
+        raise UserInterrupt(u'Interrupted while waiting to send, ZMQ client is stopping')
 
     def IsWaitingReply(self):
         return self._socket is not None
@@ -430,5 +427,4 @@ class ZmqClient(object):
             # release socket
             self._ReleaseSocket()
 
-        # TODO: raise UserInterrupt
-        return None
+        raise UserInterrupt(u'Interrupted while waiting for response, ZMQ client is stopping')


### PR DESCRIPTION
Sometimes, `zmqclient.SendCommand` returns `None`, which is bad because we don't know if it is expected or not.

When `zmqclient.SetDestroy()` is called, properly raise exception instead of returning `None`.