### PR TITLE
Add option to show config diffs in a simple format

### DIFF
--- a/bin/mujin_controllerclientpy_applyconfig.py
+++ b/bin/mujin_controllerclientpy_applyconfig.py
@@ -17,16 +17,61 @@ def _PrettifyConfig(config):
     return json.dumps(config, ensure_ascii=False, indent=2, separators=(',', ': '), sort_keys=True) + '\n'
 
 
-def _DiffConfig(oldconfig, newconfig):
+def _ShowDiffInOneLine(oldconfig, newconfig, parentPath=None, useColours=True):
+    if not (isinstance(newconfig, dict) and isinstance(oldconfig, dict)) and not (isinstance(newconfig, list) and isinstance(oldconfig, list)):
+        log.warn('Type of config needs to be either of dict or list.')
+        return
+
+    if isinstance(newconfig, list) and len(newconfig) != len(oldconfig):
+        absolutePathStr = '.'.join(parentPath or [])
+        print(('[\033[01;96mMOD\033[00m] \033[01;%dm%s\033[00m=\033[01;32m%s\033[00m (old: \033[01;31m%s\033[00m) [size changed to %s from %s]' if useColours else '[MOD] %s=%s (old: %s) [size changed to %s from %s]') % (
+            absolutePathStr, newconfig, oldconfig, len(newconfig), len(oldconfig)))
+        return
+
+    for key in sorted(newconfig) if isinstance(newconfig, dict) else range(len(newconfig)):
+        absolutePathStr = '.'.join((parentPath or []) + [key if isinstance(newconfig, dict) else '[%d]'%key])
+        if (isinstance(newconfig, dict) and key not in oldconfig):
+            print(('[\033[01;32mADD\033[00m] \033[01;32m%s\033[00m=\033[01;32m%s\033[00m' if useColours else '[ADD] %s=%s') % (absolutePathStr, newconfig[key]))
+        elif type(oldconfig[key]) != type(newconfig[key]):
+            # key exists in both confs, but types don't match
+            print(('[\033[01;96mMOD\033[00m] \033[01;96m%s\033[00m=\033[01;32m%s\033[00m (old: \033[01;31m%s\033[00m) [type changed to %s from %s]' if useColours else '[MOD] %s=%s (old: %s) [type changed to %s from %s]') % (
+                absolutePathStr, newconfig[key], oldconfig[key], type(newconfig[key]), type(oldconfig[key])))
+        else:
+            # key exists in both confs with same type values
+            if isinstance(newconfig[key], dict) or isinstance(newconfig[key], list):
+                _ShowDiffInOneLine(oldconfig[key], newconfig[key], parentPath=(parentPath or [])+[key if isinstance(newconfig, dict) else '[%d]'%key], useColours=useColours)
+            elif newconfig[key] != oldconfig[key]:
+                print(('[\033[01;96mMOD\033[00m] \033[01;96m%s\033[00m=\033[01;32m%s\033[00m (old: \033[01;31m%s\033[00m)' if useColours else '[MOD] %s=%s (old: %s)') % (absolutePathStr, newconfig[key], oldconfig[key]))
+            else:
+                pass  # same value
+
+    if isinstance(newconfig, dict):
+        for key in list(set(oldconfig.keys()) - set(newconfig.keys())):
+            absolutePathStr = '.'.join((parentPath or []) + [key])
+            print(('[\033[01;31mDEL\033[00m] \033[01;31m%s\033[00m (old: \033[01;31m%s\033[00m)' if useColours else '[DEL] %s (old: %s)') % (absolutePathStr, oldconfig[key]))
+
+
+def _DiffConfig(oldconfig, newconfig, showInOneLine=False):
     with tempfile.NamedTemporaryFile(prefix='old-config-', suffix='.json', bufsize=0) as oldfile:
         with tempfile.NamedTemporaryFile(prefix='new-config-', suffix='.json', bufsize=0) as newfile:
             oldfile.write(_PrettifyConfig(oldconfig))
             newfile.write(_PrettifyConfig(newconfig))
-            try:
-                subprocess.check_call(['diff', '--color', '--unified=5', oldfile.name, newfile.name])
-                return False
-            except subprocess.CalledProcessError:
-                return True
+            if showInOneLine:
+                res = None
+                try:
+                    subprocess.check_call(['cmp', '-s', oldfile.name, newfile.name])
+                    res = False
+                except subprocess.CalledProcessError:
+                    res = True
+                if res:
+                    _ShowDiffInOneLine(oldconfig, newconfig)
+                return res
+            else:
+                try:
+                    subprocess.check_call(['diff', '--color', '--unified=5', oldfile.name, newfile.name])
+                    return False
+                except subprocess.CalledProcessError:
+                    return True
 
 
 def _CopyValueOfPath(src, dest, path, parentPath=None):
@@ -126,12 +171,14 @@ def _RunMain():
     parser = argparse.ArgumentParser(description='Apply configuration on controller from template')
     parser.add_argument('--loglevel', action='store', type=str, dest='loglevel', default=None, help='the python log level, e.g. DEBUG, VERBOSE, ERROR, INFO, WARNING, CRITICAL [default=%(default)s]')
     parser.add_argument('--template', action='store', type=str, dest='template', required=True, help='path to template config file [default=%(default)s]')
+    parser.add_argument('--preserve', action='store', type=str, dest='preserve', default=None, help='path to a file containing the list of additional keys to preserve while merging template [default=%(default)s]')
     parser.add_argument('--controller', action='store', type=str, dest='controller', default=None, help='controller ip or hostname, e.g controller123 [default=%(default)s]')
-    parser.add_argument('--config', action='store', type=str, dest='config', default=None, help='controller ip or hostname, e.g binpickingsystem.conf [default=%(default)s]')
     parser.add_argument('--username', action='store', type=str, dest='username', default='mujin', help='controller username [default=%(default)s]')
     parser.add_argument('--password', action='store', type=str, dest='password', default='mujin', help='controller password [default=%(default)s]')
-    parser.add_argument('--force', action='store_true', dest='force', help='apply without confirmation [default=%(default)s]')
-    parser.add_argument('--preserve', action='store', type=str, dest='preserve', default=None, help='path to a file containing the list of additional keys to preserve while merging template [default=%(default)s]')
+    parser.add_argument('--config', action='store', type=str, dest='config', default=None, help='path to input config file. If specified, the config file is loaded as input instead of obtaining from controller [default=%(default)s]')
+    parser.add_argument('--force', action='store_true', dest='force', default=False, help='apply without confirmation [default=%(default)s]')
+    parser.add_argument('--dryrun', action='store_true', dest='dryrun', default=False, help='shows differences and quit [default=%(default)s]')
+    parser.add_argument('--oneline', action='store_true', dest='oneline', default=False, help='shows each difference in one line [default=%(default)s]')
     options = parser.parse_args()
 
     # configure logging
@@ -173,11 +220,13 @@ def _RunMain():
     newconfig = _ApplyTemplate(config, template, preservedpaths=preservedpaths)
 
     # if the config is different, prompt the user
-    if not _DiffConfig(config, newconfig):
+    if not _DiffConfig(config, newconfig, showInOneLine=options.oneline):
         log.debug('configuration already up-to-date on %s', target)
         return
 
     try:
+        if options.dryrun:
+            return
         log.warn('configuration will be changed on %s', target)
         if not options.force:
             six.moves.input('Are you sure about applying the above changes to %s? Press ENTER to continue ...' % target)


### PR DESCRIPTION
This patch adds an option `--oneline` to `mujin_controllerclientpy_applyconfig.py` which changes the diff formatting to simple one. This option makes it easier to work with many controllers or many changes in a conf template.

Example with `--oneline`:
```
[MOD] parameters.parameterA.[2]=-100 (old: -120)
[MOD] parameters.parameterB.[2]=250.0 (old: 100.0)
```

Same diff without `--oneline`:
```
--- /tmp/old-config-m5Y2FE.json 2020-04-22 22:40:10.416135387 +0900
+++ /tmp/new-config-lnOvdS.json 2020-04-22 22:40:10.424135377 +0900
@@ -87,11 +87,11 @@
       "use": true
     },
     "parameterA": [
       0,
       0,
-      -120
+      -100
     ],
     "blah": false,
     "blahblah": "blah",
     "blahblahblah": [
       0,
@@ -146,11 +146,11 @@
     "blah": 2000,
     "blahblah": 2000,
     "parameterB": [
       0.0,
       0.0,
-      100.0
+      250.0
     ],
     "blahblahblah": 2500,
     "a": -1,
     "b": 5,
     "c": "all",
```

This patch also adds an option `--dryrun` which just shows diffs without applying the changes.
