### PR TITLE
Remove deprecated fnname change for binpicking tasktype

### DIFF
--- a/python/mujincontrollerclient/planningclient.py
+++ b/python/mujincontrollerclient/planningclient.py
@@ -245,8 +245,6 @@ class PlanningControllerClient(controllerclientbase.ControllerClient):
             'stamp': time.time(),
             'respawnopts': respawnopts,
         }
-        if self.tasktype == 'binpicking':
-            command['fnname'] = '%s.%s' % (self.tasktype, command['fnname'])
         response = self._commandsocket.SendCommand(command, timeout=timeout, fireandforget=fireandforget, checkpreempt=checkpreempt)
 
         if fireandforget:


### PR DESCRIPTION
The line that this PR removes is specific to one of the child classes (`BinpickingControllerClient`), so it should not live in the parent `PlanningClient` class. @ziyan committed the line 6 years ago and told me that it likely has no effect at the moment. 

I tried removing the line in this branch and launched 3 autotester pipelines (starting [here](http://autotester.test.mujin.co.jp/?groupid=1&scheduleid=2&pipelineid=216473)) to test this. The change does not appear to introduce any new failures. The failures appear to be from flaky tests, as no two pipelines newly fail on the same tests.

If we want to preserve this behavior, I will submit a different PR that lets `BinpickingControllerClient` override `fnname`, but removing unused functionality is simpler. And simpler is better.