### PR TITLE
Deprecate realtimerobotclient arguments

### DIFF
--- a/python/mujincontrollerclient/realtimerobotclient.py
+++ b/python/mujincontrollerclient/realtimerobotclient.py
@@ -212,7 +212,7 @@ class RealtimeRobotControllerClient(planningclient.PlanningControllerClient):
             goals (list[float]): Flat list of goals, e.g. two 5d ik goals: [380,450,50,0,0,1, 380,450,50,0,0,-1]
             toolname (str, optional): Name of the manipulator. Default: self.toolname
             envclearance (float): Clearance in millimeter. Default: self.envclearances
-            closegripper: Whether to close gripper once the goal is reached. Default: 0
+            closegripper: (DEPRECATED) Whether to close gripper once the goal is reached. Default: 0
             robotspeed (float, optional):
             robotaccelmult (float, optional):
             timeout (float, optional):  (Default: 10)
@@ -531,7 +531,7 @@ class RealtimeRobotControllerClient(planningclient.PlanningControllerClient):
         """Removes objects with prefix.
 
         Args:
-            prefix (str, optional):
+            prefix (str, optional): (DEPRECATED)
             removeNamePrefixes (list[str], optional): Names of prefixes to match with when removing items
             timeout (float, optional):  (Default: 10)
             usewebapi (bool, optional): If True, send command through Web API. Otherwise, through ZMQ.


### PR DESCRIPTION
(No code changes, only doc)

This deprecates some arguments which are ineffectual, even though the doc may claim to do something.

- In `SaveScene` and `MoveToHandPosition`, the argument is unused
- In `RemoveObjectsWithPrefix`, the deprecation warning is in the code but not in the docstring.