### PR TITLE
Remove deprecated assignment

### DIFF
--- a/python/mujincontrollerclient/realtimerobotclient.py
+++ b/python/mujincontrollerclient/realtimerobotclient.py
@@ -240,7 +240,6 @@ class RealtimeRobotControllerClient(planningclient.PlanningControllerClient):
                           'unit': unit,
                           }
         if targetname is not None:
-            taskparameters['objectname'] = targetname
             taskparameters['object_uri'] = u'mujin:/%s.mujin.dae' % (targetname)
         taskparameters.update(kwargs)
         if state is not None:


### PR DESCRIPTION
This removes an assignment in `UpdateObjects` of `realtimerobotclient` which does not have an effect. The value is not used in `UpdateObjects` in `realtimerobottask3` or any of the functions it calls. This can be confirmed by searching for `self.goals['objectname']` and `self.goals.get('objectname')` in `realtimerobottask3`. (I also read through all the functions manually though)

Cleaning this up now will make the client generator cleaner to write.