### PR TITLE
Fix test_uriutils failures due to change in resource partType/filename behavior

### DIFF
--- a/python/mujincontrollerclient/uriutils.py
+++ b/python/mujincontrollerclient/uriutils.py
@@ -523,6 +523,14 @@ class MujinResourceIdentifier(object):
         self._fragment = _EnsureUnicode(value)
 
     @property
+    def bodyId(self):
+        return self._fragment
+
+    @bodyId.setter
+    def bodyId(self, value):
+        self._fragment = _EnsureUnicode(value)
+
+    @property
     def suffix(self):
         return self._suffix
 
@@ -585,27 +593,27 @@ class MujinResourceIdentifier(object):
         )
 
     @property
-    def filename(self):
+    def environmentId(self):
         suffix = _EnsureUTF8(self._suffix)
         if suffix and self._primaryKey.endswith(suffix):
-            basePartType = _Unquote(self._primaryKey[:-len(suffix)])
-        else:
-            basePartType = _Unquote(self._primaryKey)
+            return _Unquote(self._primaryKey[:-len(suffix)])
+        return _Unquote(self._primaryKey)
+
+    @environmentId.setter
+    def environmentId(self, value):
+        self._primaryKey = _Quote(_EnsureUnicode(value) + self._suffix)
+
+    @property
+    def filename(self):
         if not self._mujinPath:
-            return basePartType + self._suffix
-        return os.path.join(self._mujinPath, basePartType + self._suffix)
+            return self.environmentId + self._suffix
+        return os.path.join(self._mujinPath, self.environmentId + self._suffix)
     
     @property
     def partType(self):
-        suffix = _EnsureUTF8(self._suffix)
-        if suffix and self._primaryKey.endswith(suffix):
-            basePartType = _Unquote(self._primaryKey[:-len(suffix)])
-        else:
-            basePartType = _Unquote(self._primaryKey)
         if self._fragment:
-            return basePartType + self._fragmentSeparator + self._fragment
-        
-        return basePartType
+            return self.environmentId + self._fragmentSeparator + self._fragment
+        return self.environmentId
 
     @property
     def kwargs(self):

--- a/python/mujincontrollerclient/uriutils.py
+++ b/python/mujincontrollerclient/uriutils.py
@@ -598,7 +598,7 @@ class MujinResourceIdentifier(object):
         else:
             basePartType = _Unquote(self._primaryKey)
         if self._fragment:
-            return basePartType + self._fragmentSeparator + _EnsureUTF8(self._fragment)
+            return basePartType + self._fragmentSeparator + self._fragment
         
         return basePartType
 

--- a/python/mujincontrollerclient/uriutils.py
+++ b/python/mujincontrollerclient/uriutils.py
@@ -3,10 +3,14 @@
 
 """
 This file contains conversion functions between the following things:
+
 - URI (mujin:/somefolder/somefile.mujin.dae) (utf8/unicode+special urlquoted) (could have fragment) (file://abc/xxx.mujin.dae#body0_motion)
 - PrimaryKey (somefolder%2Fsomefile.mujin.dae) (ascii+urlquoted) (could have fragment) (mitsubishi%2Fmitsubishi-rv-7f.mujin.dae@body0_motion) (enforce return type to be str)
 - Filename (somefolder/somefile.mujin.dae) (utf8/unicode) (should not have fragment)
-- PartType (somefolder/somefile) (utf8/unicode) (should not have fragment)
+- PartType (somefolder/somefile) (utf8/unicode) (can have fragment)
+- EnvironmentID (somefolder/somefile) (utf8/unicode) (should not have fragment)
+- BodyID (body0_motion) (utf8/unicode) (same as fragment)
+
 All public functions in this file should be in the form of Get*From*, take fragementseparator as keyword argument as necessary, take allowfragment as necessary
 # All other functions should be internal to this file, prefixed with _
 

--- a/python/mujincontrollerclient/uriutils.py
+++ b/python/mujincontrollerclient/uriutils.py
@@ -586,9 +586,19 @@ class MujinResourceIdentifier(object):
 
     @property
     def filename(self):
+        fragment = _EnsureUTF8(self._fragment)
+        suffix = _EnsureUTF8(self._suffix)
+        primaryKeySlice = self._primaryKey
+
+        if fragment and primaryKeySlice.endswith(fragment):
+            primaryKeySlice = primaryKeySlice[:-len(fragment)]
+        if suffix and primaryKeySlice.endswith(suffix):
+            primaryKeySlice = primaryKeySlice[:-len(suffix)]
+        basePartType = _Unquote(primaryKeySlice)
+
         if not self._mujinPath:
-            return self.partType + self._suffix
-        return os.path.join(self._mujinPath, self.partType + self._suffix)
+            return basePartType + self._suffix
+        return os.path.join(self._mujinPath, basePartType + self._suffix)
     
     @property
     def partType(self):

--- a/python/mujincontrollerclient/uriutils.py
+++ b/python/mujincontrollerclient/uriutils.py
@@ -586,16 +586,11 @@ class MujinResourceIdentifier(object):
 
     @property
     def filename(self):
-        fragment = _EnsureUTF8(self._fragment)
         suffix = _EnsureUTF8(self._suffix)
-        primaryKeySlice = self._primaryKey
-
-        if fragment and primaryKeySlice.endswith(fragment):
-            primaryKeySlice = primaryKeySlice[:-len(fragment)]
-        if suffix and primaryKeySlice.endswith(suffix):
-            primaryKeySlice = primaryKeySlice[:-len(suffix)]
-        basePartType = _Unquote(primaryKeySlice)
-
+        if suffix and self._primaryKey.endswith(suffix):
+            basePartType = _Unquote(self._primaryKey[:-len(suffix)])
+        else:
+            basePartType = _Unquote(self._primaryKey)
         if not self._mujinPath:
             return basePartType + self._suffix
         return os.path.join(self._mujinPath, basePartType + self._suffix)

--- a/python/mujincontrollerclient/version.py
+++ b/python/mujincontrollerclient/version.py
@@ -1,3 +1,3 @@
-__version__ = '0.15.6'
+__version__ = '0.15.7'
 
 # Do not forget to update CHANGELOG.md

--- a/python/mujintestcontrollerclient/test_uriutils.py
+++ b/python/mujintestcontrollerclient/test_uriutils.py
@@ -65,7 +65,7 @@ def test_GetURIFromFilename(filename, mujinPath, expected):
 
 
 @pytest.mark.parametrize('primaryKey, primaryKeySeparator, expected', [
-    ('%E6%B5%8B%E8%AF%95_test..mujin.dae@body0_motion', uriutils.PRIMARY_KEY_SEPARATOR_AT, u'测试_test.body0_motion.mujin.dae'),
+    ('%E6%B5%8B%E8%AF%95_test..mujin.dae@body0_motion', uriutils.PRIMARY_KEY_SEPARATOR_AT, u'测试_test..mujin.dae'),
 ])
 def test_GetFilenameFromPrimaryKey(primaryKey, primaryKeySeparator, expected):
     assert uriutils.GetFilenameFromPrimaryKey(primaryKey, primaryKeySeparator=primaryKeySeparator) == expected

--- a/python/mujintestcontrollerclient/test_uriutils.py
+++ b/python/mujintestcontrollerclient/test_uriutils.py
@@ -65,7 +65,7 @@ def test_GetURIFromFilename(filename, mujinPath, expected):
 
 
 @pytest.mark.parametrize('primaryKey, primaryKeySeparator, expected', [
-    ('%E6%B5%8B%E8%AF%95_test..mujin.dae@body0_motion', uriutils.PRIMARY_KEY_SEPARATOR_AT, u'测试_test..mujin.dae'),
+    ('%E6%B5%8B%E8%AF%95_test..mujin.dae@body0_motion', uriutils.PRIMARY_KEY_SEPARATOR_AT, u'测试_test.body0_motion.mujin.dae'),
 ])
 def test_GetFilenameFromPrimaryKey(primaryKey, primaryKeySeparator, expected):
     assert uriutils.GetFilenameFromPrimaryKey(primaryKey, primaryKeySeparator=primaryKeySeparator) == expected
@@ -114,7 +114,7 @@ def test_GetPartTypeFromFilename(filename, mujinPath, suffix, expected):
     assert uriutils.GetPartTypeFromFilename(filename, mujinPath=mujinPath, suffix=suffix) == expected
 
 @pytest.mark.parametrize('uri, fragmentSeparator,  expected', [
-    (u'mujin:/测试_test.mujin.dae@body0_motion', uriutils.FRAGMENT_SEPARATOR_AT, u'测试_test'),
+    (u'mujin:/测试_test.mujin.dae@body0_motion', uriutils.FRAGMENT_SEPARATOR_AT, u'测试_test@body0_motion'),
     (u'mujin:/测试_test.mujin.dae', uriutils.FRAGMENT_SEPARATOR_AT, u'测试_test'),
     (u'mujin:/test.mujin.dae', uriutils.FRAGMENT_SEPARATOR_AT, u'test'),
 ])


### PR DESCRIPTION
As of 4a888c7, the `partType` and `filename` properties of a `MujinResourceIdentifier` can now incorporate the identifier's `fragment` field, which causes some of the existing `test_uriutils` tests to fail in CI.

This PR aims to fix that by correcting the expected value in the failing test cases to that produced as of 4a888c7.