### PR TITLE
Fix docstring of ComputeIkParamPosition

### DIFF
--- a/python/mujincontrollerclient/realtimerobotclient.py
+++ b/python/mujincontrollerclient/realtimerobotclient.py
@@ -822,19 +822,14 @@ class RealtimeRobotControllerClient(planningclient.PlanningControllerClient):
         return self.ExecuteCommand(taskparameters, robotname=robotname, timeout=timeout, usewebapi=usewebapi)
     
     def ComputeIkParamPosition(self, name, robotname=None, timeout=10, usewebapi=None, **kwargs):
-        """
+        """Given the name of a Kinbody, computes the manipulator (TCP) position in the kinbody frame to generate values for an IKParameterization.
 
         Args:
-            name (str):
-            robotname (str, optional): Name of the robot
-            timeout (float, optional):  (Default: 10)
+            name (str): Name of the Kinbody (the robot).
+            robotname (str, optional): (unused) Name of the robot.
+            timeout (float, optional): Time in seconds after which the command is assumed to have failed. (Default: 10)
             usewebapi (bool, optional): If True, send command through Web API. Otherwise, through ZMQ.
-            limit (int): Number of solutions to return
-            ikparamnames (list[str]): The ikparameter names, also contains information about the grasp like the preshape
-            targetname (str): The target object name that the ikparamnames belong to
-            freeincvalue (float): The discretization of the free joints of the robot when computing ik.
-            filteroptionslist (list[str]): A list of filter option strings. Can be: CheckEnvCollisions, IgnoreCustomFilters, IgnoreEndEffectorCollisions, IgnoreEndEffectorEnvCollisions, IgnoreEndEffectorSelfCollisions, IgnoreJointLimits, IgnoreSelfCollisions
-            filteroptions (int): OpenRAVE IkFilterOptions bitmask. By default this is 1, which means all collisions are checked
+            jointvalues (list, optional): If given, the robot's joints are set to these values before calculating the manipulator (TCP) position. If not set, uses the current values.
         """
         taskparameters = {
             'command': 'ComputeIkParamPosition',

--- a/python/mujincontrollerclient/realtimerobotclient.py
+++ b/python/mujincontrollerclient/realtimerobotclient.py
@@ -822,10 +822,10 @@ class RealtimeRobotControllerClient(planningclient.PlanningControllerClient):
         return self.ExecuteCommand(taskparameters, robotname=robotname, timeout=timeout, usewebapi=usewebapi)
     
     def ComputeIkParamPosition(self, name, robotname=None, timeout=10, usewebapi=None, **kwargs):
-        """Given the name of a Kinbody, computes the manipulator (TCP) position in the kinbody frame to generate values for an IKParameterization.
+        """Given the name of a Kinbody, computes the manipulator (TCP) position in the Kinbody frame to generate values for an IKParameterization.
 
         Args:
-            name (str): Name of the Kinbody (the robot).
+            name (str): Name of the Kinbody.
             robotname (str, optional): Name of the robot.
             timeout (float, optional): Time in seconds after which the command is assumed to have failed. (Default: 10)
             usewebapi (bool, optional): If True, send command through Web API. Otherwise, through ZMQ.

--- a/python/mujincontrollerclient/realtimerobotclient.py
+++ b/python/mujincontrollerclient/realtimerobotclient.py
@@ -826,7 +826,7 @@ class RealtimeRobotControllerClient(planningclient.PlanningControllerClient):
 
         Args:
             name (str): Name of the Kinbody (the robot).
-            robotname (str, optional): (unused) Name of the robot.
+            robotname (str, optional): Name of the robot.
             timeout (float, optional): Time in seconds after which the command is assumed to have failed. (Default: 10)
             usewebapi (bool, optional): If True, send command through Web API. Otherwise, through ZMQ.
             jointvalues (list, optional): If given, the robot's joints are set to these values before calculating the manipulator (TCP) position. If not set, uses the current values.


### PR DESCRIPTION
This PR removes unused parameters from the docstring. `realtimerobottask3.py` does not do anything with them.