### PR TITLE
Remove GetInertiaChildJointStartValues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.16 (2022-10-06)
+
+- Remove `GetInertiaChildJointStartValues`
+
 # 0.15.9 (2022-09-30)
 
 - Regenerate graph client.

--- a/python/mujincontrollerclient/realtimerobotclient.py
+++ b/python/mujincontrollerclient/realtimerobotclient.py
@@ -1233,18 +1233,6 @@ class RealtimeRobotControllerClient(planningclient.PlanningControllerClient):
         taskparameters.update(kwargs)
         return self.ExecuteCommand(taskparameters, usewebapi=usewebapi, timeout=timeout)
 
-    def GetInertiaChildJointStartValues(self, usewebapi=False, timeout=10, **kwargs):
-        """
-
-        Args:
-            usewebapi (bool, optional): If True, send command through Web API. Otherwise, through ZMQ. (Default: False)
-            timeout (float, optional):  (Default: 10)
-        """
-        taskparameters = dict()
-        taskparameters['command'] = 'GetInertiaChildJointStartValues'
-        taskparameters.update(kwargs)
-        return self.ExecuteCommand(taskparameters, usewebapi=usewebapi, timeout=timeout)
-
     def CalculateTestRangeFromCollision(self, usewebapi=False, timeout=10, **kwargs):
         """
 

--- a/python/mujincontrollerclient/version.py
+++ b/python/mujincontrollerclient/version.py
@@ -1,3 +1,3 @@
-__version__ = '0.15.9'
+__version__ = '0.16'
 
 # Do not forget to update CHANGELOG.md


### PR DESCRIPTION
This function does not exist in `realtimerobottask3.py`, so the call goes nowhere.