### PR TITLE
Remove ExecuteTrajectory method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.16.0 (2022-10-07)
+
+- Remove `ExecuteTrajectory` method, to avoid dangerous usage. Instead, an ITL program (e.g. with `Move`) should be executed to ensure that the trajectory is collision-free.
+
+
 # 0.15.9 (2022-09-30)
 
 - Regenerate graph client.

--- a/python/mujincontrollerclient/realtimerobotclient.py
+++ b/python/mujincontrollerclient/realtimerobotclient.py
@@ -133,20 +133,6 @@ class RealtimeRobotControllerClient(planningclient.PlanningControllerClient):
 
         return super(RealtimeRobotControllerClient, self).ExecuteCommand(taskparameters, usewebapi=usewebapi, timeout=timeout, fireandforget=fireandforget, respawnopts=respawnopts)
 
-    def ExecuteTrajectory(self, trajectoryxml, robotspeed=None, timeout=10, **kwargs):
-        """Executes a trajectory on the robot from a serialized Mujin Trajectory XML file.
-
-        Args:
-            trajectoryxml:
-            robotspeed (float, optional):
-            timeout (float, optional):  (Default: 10)
-        """
-        taskparameters = {'command': 'ExecuteTrajectory',
-                          'trajectory': trajectoryxml,
-                          }
-        taskparameters.update(kwargs)
-        return self.ExecuteCommand(taskparameters, robotspeed=robotspeed, timeout=timeout)
-
     def GetJointValues(self, timeout=10, **kwargs):
         """Gets the current robot joint values
 

--- a/python/mujincontrollerclient/version.py
+++ b/python/mujincontrollerclient/version.py
@@ -1,3 +1,3 @@
-__version__ = '0.15.9'
+__version__ = '0.16.0'
 
 # Do not forget to update CHANGELOG.md


### PR DESCRIPTION
As discussed, execution of raw trajectories is dangerous so it should not be a public API.

cc @kanbouchou 